### PR TITLE
fix typo

### DIFF
--- a/Disco_Diffusion.ipynb
+++ b/Disco_Diffusion.ipynb
@@ -304,7 +304,7 @@
         "**Init settings:**\n",
         "`init_image` |   URL or local path | None\n",
         "`init_scale` |  This enhances the effect of the init image, a good value is 1000 | 0\n",
-        "`skip_steps Controls the starting point along the diffusion timesteps | 0\n",
+        "`skip_steps` | Controls the starting point along the diffusion timesteps | 0\n",
         "`perlin_init` |  Option to start with random perlin noise | False\n",
         "`perlin_mode` |  ('gray', 'color') | 'mixed'\n",
         "**Advanced:**\n",


### PR DESCRIPTION
Typo on line 307 that breaks the tutorial table is fixed.