### PR TITLE
update init_image param to take None

### DIFF
--- a/Disco_Diffusion.ipynb
+++ b/Disco_Diffusion.ipynb
@@ -1068,7 +1068,7 @@
         "      \n",
         "      # Inits if not video frames\n",
         "      if args.animation_mode != \"Video Input\":\n",
-        "        if args.init_image == '':\n",
+        "        if args.init_image == '' or args.init_image.lower() == 'none':\n",
         "          init_image = None\n",
         "        else:\n",
         "          init_image = args.init_image\n",

--- a/disco.py
+++ b/disco.py
@@ -1031,7 +1031,7 @@ def do_run():
       
       # Inits if not video frames
       if args.animation_mode != "Video Input":
-        if args.init_image == '':
+        if args.init_image == '' or args.init_image.lower() == 'none':
           init_image = None
         else:
           init_image = args.init_image


### PR DESCRIPTION
update init_image param to take None as an argument instead of erroring in a lot of cases people asking how to set it when initially it is set to None but doesn't fail because the param wants a string but default is a type None wich leads to confusion about entering None in if they set one and do not want it anymore 