### PR TITLE
Fix docker model links

### DIFF
--- a/docker/main/Dockerfile
+++ b/docker/main/Dockerfile
@@ -33,7 +33,7 @@ RUN git clone https://github.com/alembics/disco-diffusion.git && \
     git clone https://github.com/shariqfarooq123/AdaBins.git
 
 # Install Python packages
-RUN pip install imageio imageio-ffmpeg==0.4.4 pyspng==0.1.0 lpips datetime timm ipywidgets omegaconf>=2.0.0 pytorch-lightning>=1.0.8 torch-fidelity einops wandb pandas ftfy
+RUN pip install imageio imageio-ffmpeg==0.4.4 pyspng==0.1.0 lpips datetime timm ipywidgets omegaconf>=2.0.0 pytorch-lightning>=1.0.8 torch-fidelity einops wandb pandas ftfy opencv-python regex clip matplotlib
 
 # Precache other big files
 COPY --chown=disco --from=modelprep /scratch/clip /home/disco/.cache/clip

--- a/docker/main/Dockerfile
+++ b/docker/main/Dockerfile
@@ -29,7 +29,7 @@ RUN git clone https://github.com/alembics/disco-diffusion.git && \
     git clone https://github.com/assafshocher/ResizeRight.git && \
     git clone https://github.com/MSFTserver/pytorch3d-lite.git && \
     git clone https://github.com/isl-org/MiDaS.git && \
-    git clone https://github.com/crowsonkb/guided-diffusion.git && \
+    git clone https://github.com/kostarion/guided-diffusion.git && \
     git clone https://github.com/shariqfarooq123/AdaBins.git
 
 # Install Python packages

--- a/docker/prep/Dockerfile
+++ b/docker/prep/Dockerfile
@@ -9,9 +9,9 @@ FROM nvcr.io/nvidia/pytorch:21.08-py3 AS prep
     RUN wget --progress=bar:force:noscroll -P /scratch/model-lpips https://download.pytorch.org/models/vgg16-397923af.pth 
 
     RUN wget --no-directories --progress=bar:force:noscroll -P /scratch/models https://github.com/intel-isl/DPT/releases/download/1_0/dpt_large-midas-2f21e586.pt
-    RUN wget --no-directories --progress=bar:force:noscroll -P /scratch/models https://v-diffusion.s3.us-west-2.amazonaws.com/512x512_diffusion_uncond_finetune_008100.pt
+    RUN wget --no-directories --progress=bar:force:noscroll -P /scratch/models https://the-eye.eu/public/AI/models/512x512_diffusion_unconditional_ImageNet/512x512_diffusion_uncond_finetune_008100.pt
     RUN wget --no-directories --progress=bar:force:noscroll -P /scratch/models https://openaipublic.blob.core.windows.net/diffusion/jul-2021/256x256_diffusion_uncond.pt
-    RUN wget --no-directories --progress=bar:force:noscroll -P /scratch/models https://v-diffusion.s3.us-west-2.amazonaws.com/secondary_model_imagenet_2.pth
+    RUN wget --no-directories --progress=bar:force:noscroll -P /scratch/models https://the-eye.eu/public/AI/models/v-diffusion/secondary_model_imagenet_2.pth
 
     RUN wget --no-directories --progress=bar:force:noscroll -P /scratch/pretrained https://cloudflare-ipfs.com/ipfs/Qmd2mMnDLWePKmgfS8m6ntAg4nhV5VkUyAydYBp8cWWeB7/AdaBins_nyu.pt
 


### PR DESCRIPTION
When applied this PR will:
- fix broken links in the `disco-diffusion-prep` docker
- add missing dependencies to the `disco-diffusion` docker 

Tested on
- OS: Ubuntu 20.04
- GPU: RTX 3080
- Base Diffusion Settings with only ViTB32 and ViTB16 enabled