### PR TITLE
Add v5.61 versioning and changelog notes

### DIFF
--- a/Disco_Diffusion.ipynb
+++ b/Disco_Diffusion.ipynb
@@ -16,7 +16,7 @@
         "id": "TitleTop"
       },
       "source": [
-        "# Disco Diffusion v5.6 - Now with portrait_generator_v001\n",
+        "# Disco Diffusion v5.61 - Now with portrait_generator_v001\n",
         "\n",
         "Disco Diffusion - http://discodiffusion.com/ , https://github.com/alembics/disco-diffusion\n",
         "\n",
@@ -325,6 +325,11 @@
         "  v5.6 Update: Jul 13th 2022 - Felipe3DArtist integration by gandamu / Adam Letts\n",
         "\n",
         "      portrait_generator_v001 diffusion model integrated\n",
+        "\n",
+        "  v5.61 Update: Aug 21st 2022 - gandamu / Adam Letts\n",
+        "\n",
+        "      Correct progress bars issue caused by recent Google Colab environment changes\n",
+        "      Adjust 512x512 diffusion model download URI priority due to issues with the previous primary source\n",
         "    '''\n",
         "  )"
       ],
@@ -3359,7 +3364,7 @@
         "FlowFns2"
       ],
       "machine_shape": "hm",
-      "name": "Disco Diffusion v5.6 [Now with portrait_generator_v001]",
+      "name": "Disco Diffusion v5.61 [Now with portrait_generator_v001]",
       "private_outputs": true,
       "provenance": [],
       "include_colab_link": true

--- a/disco.py
+++ b/disco.py
@@ -12,7 +12,7 @@
 # !!   "id": "TitleTop"
 # !! }}
 """
-# Disco Diffusion v5.6 - Now with portrait_generator_v001
+# Disco Diffusion v5.61 - Now with portrait_generator_v001
 
 Disco Diffusion - http://discodiffusion.com/ , https://github.com/alembics/disco-diffusion
 
@@ -314,6 +314,11 @@ if skip_for_run_all == False:
   v5.6 Update: Jul 13th 2022 - Felipe3DArtist integration by gandamu / Adam Letts
 
       portrait_generator_v001 diffusion model integrated
+
+  v5.61 Update: Aug 21st 2022 - gandamu / Adam Letts
+
+      Correct progress bars issue caused by recent Google Colab environment changes
+      Adjust 512x512 diffusion model download URI priority due to issues with the previous primary source
     '''
   )
 
@@ -3252,7 +3257,7 @@ else:
 # !!       "FlowFns2"
 # !!     ],
 # !!     "machine_shape": "hm",
-# !!     "name": "Disco Diffusion v5.6 [Now with portrait_generator_v001]",
+# !!     "name": "Disco Diffusion v5.61 [Now with portrait_generator_v001]",
 # !!     "private_outputs": true,
 # !!     "provenance": [],
 # !!     "include_colab_link": true


### PR DESCRIPTION
Add v5.61 versioning and changelog notes (corresponding to progressbar fix and 512x512 diffusion model download link update)