### PR TITLE
pin MiDaS to V3, issue #164, use depth 1 for git clone

### DIFF
--- a/Disco_Diffusion.ipynb
+++ b/Disco_Diffusion.ipynb
@@ -3,8 +3,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "view-in-github"
       },
       "source": [
         "<a href=\"https://colab.research.google.com/github/alembics/disco-diffusion/blob/main/Disco_Diffusion.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
@@ -31,7 +31,7 @@
         "id": "CreditsChTop"
       },
       "source": [
-        "### Credits & Changelog \u2b07\ufe0f"
+        "### Credits & Changelog ⬇️"
       ]
     },
     {
@@ -197,10 +197,12 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "cellView": "form",
         "id": "Changelog"
       },
+      "outputs": [],
       "source": [
         "#@title <- View Changelog\n",
         "skip_for_run_all = True #@param {type: 'boolean'}\n",
@@ -332,9 +334,7 @@
         "      Adjust 512x512 diffusion model download URI priority due to issues with the previous primary source\n",
         "    '''\n",
         "  )"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
       "cell_type": "markdown",
@@ -420,10 +420,12 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "cellView": "form",
         "id": "CheckGPU"
       },
+      "outputs": [],
       "source": [
         "#@title 1.1 Check GPU Status\n",
         "import subprocess\n",
@@ -438,25 +440,32 @@
         "    print(nvidiasmi_output)\n",
         "    nvidiasmi_ecc_note = subprocess.run(['nvidia-smi', '-i', '0', '-e', '0'], stdout=subprocess.PIPE).stdout.decode('utf-8')\n",
         "    print(nvidiasmi_ecc_note)"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "cellView": "form",
         "id": "PrepFolders"
       },
+      "outputs": [],
       "source": [
         "#@title 1.2 Prepare Folders\n",
         "import subprocess, os, sys, ipykernel\n",
         "\n",
-        "def gitclone(url, targetdir=None):\n",
+        "def gitclone(url, targetdir=None, branch_tag=None):\n",
+        "    call_args = ['git', 'clone', '--depth', '1']\n",
+        "\n",
+        "    if branch_tag:\n",
+        "        call_args.extend(['--branch', branch_tag])\n",
+        "\n",
+        "    call_args.append(url)    \n",
+        "    \n",
         "    if targetdir:\n",
-        "        res = subprocess.run(['git', 'clone', url, targetdir], stdout=subprocess.PIPE).stdout.decode('utf-8')\n",
-        "    else:\n",
-        "        res = subprocess.run(['git', 'clone', url], stdout=subprocess.PIPE).stdout.decode('utf-8')\n",
+        "        call_args.append(targetdir)\n",
+        "    \n",
+        "    res = subprocess.run(call_args, stdout=subprocess.PIPE).stdout.decode('utf-8')\n",
         "    print(res)\n",
         "\n",
         "def pipi(modulestr):\n",
@@ -521,16 +530,16 @@
         "\n",
         "# libraries = f'{root_path}/libraries'\n",
         "# createPath(libraries)"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "cellView": "form",
         "id": "InstallDeps"
       },
+      "outputs": [],
       "source": [
         "#@title ### 1.3 Install, import dependencies and set up runtime devices\n",
         "\n",
@@ -610,7 +619,7 @@
         "    from midas.dpt_depth import DPTDepthModel\n",
         "except:\n",
         "    if not os.path.exists('MiDaS'):\n",
-        "        gitclone(\"https://github.com/isl-org/MiDaS.git\")\n",
+        "        gitclone(\"https://github.com/isl-org/MiDaS.git\", branch_tag='v3')\n",
         "    if not os.path.exists('MiDaS/midas_utils.py'):\n",
         "        shutil.move('MiDaS/utils.py', 'MiDaS/midas_utils.py')\n",
         "    if not os.path.exists(f'{model_path}/dpt_large-midas-2f21e586.pt'):\n",
@@ -695,16 +704,16 @@
         "    if torch.cuda.get_device_capability(DEVICE) == (8,0): ## A100 fix thanks to Emad\n",
         "        print('Disabling CUDNN for A100 gpu', file=sys.stderr)\n",
         "        torch.backends.cudnn.enabled = False"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "cellView": "form",
         "id": "DefMidasFns"
       },
+      "outputs": [],
       "source": [
         "#@title ### 1.4 Define Midas functions\n",
         "\n",
@@ -807,16 +816,16 @@
         "\n",
         "    print(f\"MiDaS '{midas_model_type}' depth model initialized.\")\n",
         "    return midas_model, midas_transform, net_w, net_h, resize_mode, normalization"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "cellView": "form",
         "id": "DefFns"
       },
+      "outputs": [],
       "source": [
         "#@title 1.5 Define necessary functions\n",
         "\n",
@@ -1691,16 +1700,16 @@
         "    # print('Settings:', setting_list)\n",
         "    with open(f\"{batchFolder}/{batch_name}({batchNum})_settings.txt\", \"w+\", encoding=\"utf-8\") as f:   #save settings\n",
         "        json.dump(setting_list, f, ensure_ascii=False, indent=4)"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "cellView": "form",
         "id": "DefSecModel"
       },
+      "outputs": [],
       "source": [
         "#@title 1.6 Define the secondary diffusion model\n",
         "\n",
@@ -1865,9 +1874,7 @@
         "        pred = input * alphas - v * sigmas\n",
         "        eps = input * sigmas + v * alphas\n",
         "        return DiffusionOutput(v, pred, eps)"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1880,9 +1887,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "ModelSettings"
       },
+      "outputs": [],
       "source": [
         "#@markdown ####**Models Settings (note: For pixel art, the best is pixelartdiffusion_expanded):**\n",
         "diffusion_model = \"512x512_diffusion_uncond_finetune_008100\" #@param [\"256x256_diffusion_uncond\", \"512x512_diffusion_uncond_finetune_008100\", \"portrait_generator_v001\", \"pixelartdiffusion_expanded\", \"pixel_art_diffusion_hard_256\", \"pixel_art_diffusion_soft_256\", \"pixelartdiffusion4k\", \"watercolordiffusion_2\", \"watercolordiffusion\", \"PulpSciFiDiffusion\", \"custom\"]\n",
@@ -2088,9 +2097,7 @@
         "\n",
         "normalize = T.Normalize(mean=[0.48145466, 0.4578275, 0.40821073], std=[0.26862954, 0.26130258, 0.27577711])\n",
         "lpips_model = lpips.LPIPS(net='vgg').to(device)"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2104,9 +2111,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "CustModel"
       },
+      "outputs": [],
       "source": [
         "#@markdown ####**Custom Model Settings:**\n",
         "if diffusion_model == 'custom':\n",
@@ -2126,9 +2135,7 @@
         "          'use_fp16': True,\n",
         "          'use_scale_shift_norm': False,\n",
         "      })"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2141,9 +2148,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "BasicSettings"
       },
+      "outputs": [],
       "source": [
         "#@markdown ####**Basic Settings:**\n",
         "batch_name = 'TimeToDisco' #@param{type: 'string'}\n",
@@ -2187,9 +2196,7 @@
         "#Make folder for batch\n",
         "batchFolder = f'{outDirPath}/{batch_name}'\n",
         "createPath(batchFolder)"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2202,9 +2209,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "AnimSettings"
       },
+      "outputs": [],
       "source": [
         "#@markdown ####**Animation Mode:**\n",
         "animation_mode = 'None' #@param ['None', '2D', '3D', 'Video Input'] {type:'string'}\n",
@@ -2574,15 +2583,15 @@
         "    rotation_3d_x = float(rotation_3d_x)\n",
         "    rotation_3d_y = float(rotation_3d_y)\n",
         "    rotation_3d_z = float(rotation_3d_z)"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "InstallRAFT"
       },
+      "outputs": [],
       "source": [
         "#@title Install RAFT for Video input animation mode only\n",
         "#@markdown Run once per session. Doesn't download again if model path exists.\n",
@@ -2602,15 +2611,15 @@
         "        sub_p_res = subprocess.run(['bash', f'{PROJECT_DIR}/RAFT/download_models.sh'], stdout=subprocess.PIPE).stdout.decode('utf-8')\n",
         "        print(sub_p_res)\n",
         "        os.chdir(PROJECT_DIR)"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "FlowFns1"
       },
+      "outputs": [],
       "source": [
         "#@title Define optical flow functions for Video input animation mode only\n",
         "if animation_mode == 'Video Input':\n",
@@ -2748,15 +2757,15 @@
         "    # TBD flow backwards!\n",
         "  \n",
         "    os.chdir(PROJECT_DIR)"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "FlowFns2"
       },
+      "outputs": [],
       "source": [
         "#@title Generate optical flow and consistency maps\n",
         "#@markdown Run once per init video\n",
@@ -2814,9 +2823,7 @@
         "\n",
         "                del raft_model \n",
         "                gc.collect()"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2830,9 +2837,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "ExtraSettings"
       },
+      "outputs": [],
       "source": [
         "#@markdown ####**Saving:**\n",
         "\n",
@@ -2921,9 +2930,7 @@
         "use_vertical_symmetry = False #@param {type:\"boolean\"}\n",
         "use_horizontal_symmetry = False #@param {type:\"boolean\"}\n",
         "transformation_percent = [0.09] #@param"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2937,9 +2944,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "Prompts"
       },
+      "outputs": [],
       "source": [
         "# Note: If using a pixelart diffusion model, try adding \"#pixelart\" to the end of the prompt for a stronger effect. It'll tend to work a lot better!\n",
         "text_prompts = {\n",
@@ -2950,9 +2959,7 @@
         "image_prompts = {\n",
         "    # 0:['ImagePromptsWorkButArentVeryGood.png:2',],\n",
         "}"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2965,9 +2972,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "DoTheRun"
       },
+      "outputs": [],
       "source": [
         "#@title Do the Run!\n",
         "#@markdown `n_batches` ignored with animation modes.\n",
@@ -3193,9 +3202,7 @@
         "    print('Seed used:', seed)\n",
         "    gc.collect()\n",
         "    torch.cuda.empty_cache()"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
       "cell_type": "markdown",
@@ -3208,10 +3215,12 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "CreateVid",
-        "cellView": "form"
+        "cellView": "form",
+        "id": "CreateVid"
       },
+      "outputs": [],
       "source": [
         "import PIL\n",
         "# @title ### **Create video**\n",
@@ -3338,14 +3347,12 @@
         "    #     mp4 = open(filepath,'rb').read()\n",
         "    #     data_url = \"data:video/mp4;base64,\" + b64encode(mp4).decode()\n",
         "    #     display.HTML(f'<video width=400 controls><source src=\"{data_url}\" type=\"video/mp4\"></video>')"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     }
   ],
   "metadata": {
-    "anaconda-cloud": {},
     "accelerator": "GPU",
+    "anaconda-cloud": {},
     "colab": {
       "collapsed_sections": [
         "CreditsChTop",
@@ -3363,11 +3370,11 @@
         "FlowFns1",
         "FlowFns2"
       ],
+      "include_colab_link": true,
       "machine_shape": "hm",
       "name": "Disco Diffusion v5.61 [Now with portrait_generator_v001]",
       "private_outputs": true,
-      "provenance": [],
-      "include_colab_link": true
+      "provenance": []
     },
     "kernelspec": {
       "display_name": "Python 3",


### PR DESCRIPTION
Fixes Issue #164 by pinning the MidaS to V3.
The gitclone method can now take an optional branch_tag name and the clone is limited to depth 1, to get faster downloads.